### PR TITLE
Relax Ruby version requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.4.3'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.1'
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,8 +315,5 @@ DEPENDENCIES
   valkyrie (~> 1.2.0)
   web-console (>= 3.3.0)
 
-RUBY VERSION
-   ruby 2.4.3p205
-
 BUNDLED WITH
    1.16.4


### PR DESCRIPTION
I couldn't `bundle install` because I didn't have Ruby 2.4.3 installed. I have 2.4.1, which works fine. I'm guessing we don't need to be too stringent on which versions of Ruby we'll need.